### PR TITLE
Fix the problem of compilation failure

### DIFF
--- a/smartpqi_kernel_compat.h
+++ b/smartpqi_kernel_compat.h
@@ -298,7 +298,7 @@
 #endif
 #if !defined(KFEATURE_HAS_USE_CLUSTERING)
 #define KFEATURE_HAS_USE_CLUSTERING			1
-#define IOCTL_INT int
+#define IOCTL_INT unsigned int
 #endif
 #if !defined(KFEATURE_HAS_OLD_TIMER)
 #define KFEATURE_HAS_OLD_TIMER				0


### PR DESCRIPTION
Fix the problem of compilation failure under the arm architecture on the UnionTech OS operating system.

Signed-off-by: liugang <liuganga@uniontech.com>